### PR TITLE
delete wrong filenames cuting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,9 +55,8 @@ const FSStorage = (location = DocumentDir, folder = 'reduxPersist') => {
     await FileSystem.makeDirectoryAsync(baseFolder, {
       intermediates: true
     });
-    const baseFolderLength = baseFolder.length;
     const files = await FileSystem.readDirectoryAsync(baseFolder);
-    return files.map(fileUri => decodeURIComponent(fileUri.substring(baseFolderLength)));
+    return files.map(fileUri => decodeURIComponent(fileUri));
   });
 
   return {


### PR DESCRIPTION
readDirectoryAsync return filenames, no paths