### PR TITLE
Fix removing 2 of the slashes from "file:///"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ import * as FileSystem from 'expo-file-system';
 export const DocumentDir = FileSystem.documentDirectory;
 export const CacheDir = FileSystem.cacheDirectory;
 
-const resolvePath = (...paths) => paths.join('/').split('/').filter(part => part && part !== '.').join('/');
+const resolvePath = (...paths) => paths.join('/').split('/').filter(part => part !== '.').join('/');
 
 // Wrap function to support both Promise and callback
 async function withCallback(callback, func) {


### PR DESCRIPTION
resolvePath is currently converting `fill:///` to `file:/`.  With Expo SDK 42 on Android, this fails silently by not creating files or directories.